### PR TITLE
issues product edit until tab is loaded

### DIFF
--- a/src/app/code/community/Younkim/TwoWayLink/Model/Observer.php
+++ b/src/app/code/community/Younkim/TwoWayLink/Model/Observer.php
@@ -80,6 +80,9 @@ class Younkim_TwoWayLink_Model_Observer
 
         // Grab related product link data
         $relatedLinkData = $product->getRelatedLinkData();
+        if (is_null($relatedLinkData)) {
+            return;
+        }
         $relatedLinkData[$product->getId()] = array('position' => null);
 
 


### PR DESCRIPTION
resolve issues in product edit that removes links if tab related is not loaded